### PR TITLE
Switch to using "images" over "image"

### DIFF
--- a/berbix_test.go
+++ b/berbix_test.go
@@ -96,12 +96,16 @@ func TestCreateAPIOnlyTransaction(t *testing.T) {
 
 	t.Logf("total number of bytes in image: %d", len(frontBytes))
 
-	opts := &UploadImageOptions{
-		image:   frontBytes,
-		subject: ImageSubjectDocumentFront,
-		format:  ImageFormatJPEG,
+	opts := &UploadImagesOptions{
+		Images: []RawImage{
+			{
+				Image:   frontBytes,
+				Subject: ImageSubjectDocumentFront,
+				Format:  ImageFormatJPEG,
+			},
+		},
 	}
-	upRes, err := client.UploadImage(&createRes.Tokens, opts)
+	upRes, err := client.UploadImages(&createRes.Tokens, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,12 +115,16 @@ func TestCreateAPIOnlyTransaction(t *testing.T) {
 		t.Errorf("expected next step of %q but got %q", expectedNextStep, upRes.NextStep)
 	}
 
-	opts = &UploadImageOptions{
-		image:   frontBytes,
-		subject: ImageSubjectDocumentFront,
-		format:  ImageFormatJPEG,
+	opts = &UploadImagesOptions{
+		Images: []RawImage{
+			{
+				Image:   frontBytes,
+				Subject: ImageSubjectDocumentFront,
+				Format:  ImageFormatJPEG,
+			},
+		},
 	}
-	_, err = client.UploadImage(&createRes.Tokens, opts)
+	_, err = client.UploadImages(&createRes.Tokens, opts)
 	if _, ok := err.(InvalidStateErr); !ok {
 		t.Errorf("expected invalid state error, got %v", err)
 	}
@@ -166,12 +174,16 @@ func TestOverrideAPIOnlyTransaction(t *testing.T) {
 	}
 
 	t.Logf("total number of bytes in image: %d", len(frontBytes))
-	opts := &UploadImageOptions{
-		image:   frontBytes,
-		subject: ImageSubjectDocumentFront,
-		format:  ImageFormatJPEG,
+	opts := &UploadImagesOptions{
+		Images: []RawImage{
+			{
+				Image:   frontBytes,
+				Subject: ImageSubjectDocumentFront,
+				Format:  ImageFormatJPEG,
+			},
+		},
 	}
-	upRes, err := client.UploadImage(&createRes.Tokens, opts)
+	upRes, err := client.UploadImages(&createRes.Tokens, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,12 +272,16 @@ func TestUploadOversizedImageAPIOnly(t *testing.T) {
 	}
 
 	tooManyBytes := make([]byte, 11*1024*1024*1024)
-	opts := &UploadImageOptions{
-		image:   tooManyBytes,
-		subject: ImageSubjectDocumentFront,
-		format:  ImageFormatJPEG,
+	opts := &UploadImagesOptions{
+		Images: []RawImage{
+			{
+				Image:   tooManyBytes,
+				Subject: ImageSubjectDocumentFront,
+				Format:  ImageFormatJPEG,
+			},
+		},
 	}
-	_, err = client.UploadImage(&createRes.Tokens, opts)
+	_, err = client.UploadImages(&createRes.Tokens, opts)
 	if _, ok := err.(PayloadTooLargeErr); !ok {
 		t.Errorf("expected to get a PayloadTooLargeErr, but got %v", err)
 	}

--- a/types.go
+++ b/types.go
@@ -188,7 +188,7 @@ type ImageData struct {
 }
 
 type ImageUploadRequest struct {
-	Image ImageData `json:"image"`
+	Images []ImageData `json:"images"`
 }
 
 type NextStep string


### PR DESCRIPTION
Update: deprecating this in favor of a PR on `ChristianHansen/berbix-go`

I'll make a separate PR after this one gets stamped into the public `berbix-go`.

Updates API-only image uploads to use the `images` JSON property instead of the soon-to-be-deprecated `image`.  See https://github.com/berbix/berbix/pull/5950 .

Also exports struct members that need to be exported for `UploadImagesOptions` to be usable.

TODO: still need to test this against my local dev env